### PR TITLE
Add bibtex-format "biblatex"

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ To add a list of formatted references, place `bibliography::[]` on a line by its
 
 ### Document Attributes
 
-| Attribute Name | Description                              | Valid Values                      | Default Value       |
-| -------------- | ---------------                          | ----------                        | --------------      |
-| bibtex-file    | Bibtex database file                     | any string, or empty              | Automatic searching |
-| bibtex-style   | Reference formatting style               | any style supported by csl-styles | ieee                |
-| bibtex-order   | Order of citations                       | `appearance` or `alphabetical`    | `appearance`        |
-| bibtex-format  | Formatting of citations and bibliography | `asciidoc` or `latex`             | `asciidoc`          |
+| Attribute Name | Description                              | Valid Values                         | Default Value       |
+| -------------- | ---------------                          | ----------                           | --------------      |
+| bibtex-file    | Bibtex database file                     | any string, or empty                 | Automatic searching |
+| bibtex-style   | Reference formatting style               | any style supported by csl-styles    | ieee                |
+| bibtex-order   | Order of citations                       | `appearance` or `alphabetical`       | `appearance`        |
+| bibtex-format  | Formatting of citations and bibliography | `asciidoc` or `bibtex` or `biblatex` | `asciidoc`          |
 
 ### Commandline
 

--- a/lib/asciidoctor-bibtex/bibextension.rb
+++ b/lib/asciidoctor-bibtex/bibextension.rb
@@ -123,9 +123,11 @@ module AsciidoctorBibtex
         end
 
         references_asciidoc = []
-        if bibtex_format == :latex
+        if bibtex_format == :latex or bibtex_format == :bibtex
           references_asciidoc << %(+++\\bibliography{#{bibtex_file}}{}+++)
           references_asciidoc << %(+++\\bibliographystyle{#{bibtex_style}}+++)
+        elsif bibtex_format == :biblatex
+          references_asciidoc << %(+++\\printbibliography+++)
         else
           processor.cites.each do |ref|
             references_asciidoc << processor.get_reference(ref)

--- a/lib/asciidoctor-bibtex/processor.rb
+++ b/lib/asciidoctor-bibtex/processor.rb
@@ -23,7 +23,7 @@ module AsciidoctorBibtex
       @output = output
       @bibfile = bibfile
 
-      if output != :latex
+      if output != :latex and output != :bibtex and output != :biblatex
         @citeproc = CiteProc::Processor.new style: @style, format: :html
         @citeproc.import @biblio.to_citeproc
       end
@@ -32,7 +32,7 @@ module AsciidoctorBibtex
     # Return the complete citation text for given cite_data
     def complete_citation cite_data
 
-      if @output == :latex
+      if @output == :latex or @output == :bibtex or @output == :biblatex
         result = '+++'
         cite_data.cites.each do |cite|
           # NOTE: xelatex does not support "\citenp", so we output all


### PR DESCRIPTION
For consistency reasons, also rename bibtex-format "latex" to "bibtex".
The old name is still accepted to preserve compatibility.

Fixes #26