### PR TITLE
Use \textcite and \parencite instead of \cite with biblatex

### DIFF
--- a/lib/asciidoctor-bibtex/processor.rb
+++ b/lib/asciidoctor-bibtex/processor.rb
@@ -36,9 +36,16 @@ module AsciidoctorBibtex
         result = '+++'
         cite_data.cites.each do |cite|
           # NOTE: xelatex does not support "\citenp", so we output all
-          # references as "cite" here.
-          # result << "\\" << cite_data.type
-          result << "\\" << 'cite'
+          # references as "cite" here unless we're using biblatex.
+          if @output == :biblatex
+            if cite_data.type == "citenp"
+              result << "\\" << 'textcite'
+            else
+              result << "\\" << 'parencite'
+            end
+          else
+            result << "\\" << 'cite'
+          end
           if cite.pages != ''
             result << "[p. " << cite.pages << "]"
           end


### PR DESCRIPTION
`\textcite` creates a citation suitable to be used in the flow of text, which is what citenp aims to do as well and `\parencite` results in a citation wrapped in parentheses. 

This way, the citations created should most closely mirror what the asciidoc output does.
