### PR TITLE
Introducing a configurable locale for BibTeX

### DIFF
--- a/lib/asciidoctor-bibtex/bibextension.rb
+++ b/lib/asciidoctor-bibtex/bibextension.rb
@@ -64,6 +64,10 @@ module AsciidoctorBibtex
         if attrs.key? :style and not parent.document.attr? 'bibtex-style'
           parent.document.set_attribute 'bibtex-style', attrs[:style]
         end
+        if attrs.key? :locale and not parent.document.attr? 'bibtex-locale'
+          parent.document.set_attribute 'bibtex-locale', attrs[:locale]
+        end
+        create_paragraph parent, BibliographyBlockMacroPlaceholder, {}
         create_paragraph parent, BibliographyBlockMacroPlaceholder, {}
       end
     end
@@ -77,6 +81,7 @@ module AsciidoctorBibtex
       def process document
         bibtex_file = (document.attr 'bibtex-file').to_s
         bibtex_style = ((document.attr 'bibtex-style') || 'ieee').to_s
+        bibtex_locale = ((document.attr 'bibtex-locale') || 'en-US').to_s
         bibtex_order = ((document.attr 'bibtex-order') || 'appearance').to_sym
         bibtex_format = ((document.attr 'bibtex-format') || 'asciidoc').to_sym
 
@@ -92,7 +97,7 @@ module AsciidoctorBibtex
         end
 
         bibtex = BibTeX.open bibtex_file, :filter => [LatexFilter]
-        processor = Processor.new bibtex, true, bibtex_style, bibtex_order == :appearance, bibtex_format
+        processor = Processor.new bibtex, true, bibtex_style, bibtex_locale, bibtex_order == :appearance, bibtex_format
 
         prose_blocks = document.find_by {|b| b.content_model == :simple or b.context == :list_item}
         prose_blocks.each do |block|

--- a/lib/asciidoctor-bibtex/bibextension.rb
+++ b/lib/asciidoctor-bibtex/bibextension.rb
@@ -68,7 +68,6 @@ module AsciidoctorBibtex
           parent.document.set_attribute 'bibtex-locale', attrs[:locale]
         end
         create_paragraph parent, BibliographyBlockMacroPlaceholder, {}
-        create_paragraph parent, BibliographyBlockMacroPlaceholder, {}
       end
     end
 

--- a/lib/asciidoctor-bibtex/processor.rb
+++ b/lib/asciidoctor-bibtex/processor.rb
@@ -13,18 +13,19 @@ module AsciidoctorBibtex
 
     attr_reader :biblio, :links, :style, :citations
 
-    def initialize biblio, links, style, numeric_in_appearance_order = false, output = :asciidoc, bibfile = ""
+    def initialize biblio, links, style, locale, numeric_in_appearance_order = false, output = :asciidoc, bibfile = ""
       @biblio = biblio
       @links = links
       @numeric_in_appearance_order = numeric_in_appearance_order
       @style = style
+	  @locale = locale
       @citations = Citations.new
       @filenames = Set.new
       @output = output
       @bibfile = bibfile
 
       if output != :latex and output != :bibtex and output != :biblatex
-        @citeproc = CiteProc::Processor.new style: @style, format: :html
+        @citeproc = CiteProc::Processor.new style: @style, format: :html, locale: @locale
         @citeproc.import @biblio.to_citeproc
       end
     end


### PR DESCRIPTION
* A new parameter `bibtex-locale` is introduced, defaulting to en-US
* The new parameter can be set to any of the CLS locales
* The parameter will be given to the BibTex processor to produce localized output

This would satisfy, if not close issue #34

Please excuse that I am a total ruby newbie, so you might want to look over the code and maybe include some other additions to comply with your coding style. I mainly deducted what we would need for the feature to work and tested it successfully.