### PR TITLE
Fix typo: fild_bibfile -> find_bibfile

### DIFF
--- a/lib/asciidoctor-bibtex/extensions.rb
+++ b/lib/asciidoctor-bibtex/extensions.rb
@@ -70,7 +70,7 @@ module AsciidoctorBibtex
 
         # Fild bibtex file automatically if not supplied.
         if bibtex_file.empty?
-          bibtex_file = AsciidoctorBibtex::PathUtils.fild_bibfile '.'
+          bibtex_file = AsciidoctorBibtex::PathUtils.find_bibfile '.'
         end
         if bibtex_file.empty?
           bibtex_file = AsciidoctorBibtex::PathUtils.find_bibfile "#{ENV['HOME']}/Documents"


### PR DESCRIPTION
This was introduced with the 0.5.0 release.