### PR TITLE
Fix pretext example

### DIFF
--- a/samples/all-in-one/sample.adoc
+++ b/samples/all-in-one/sample.adoc
@@ -14,7 +14,7 @@ citenp:[Lane12a].
 
 Page numbers (locators) can be added: cite:[Lane12a(89)] or citenp:[Lane12a(89-93)].
 
-A bit of pretext can be included too: See cite:see[Lane12a(89)]
+A bit of pretext can be included too: cite:See[Lane12a(89)]
 
 We can include other files, which are also processed:
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/Lexikos/AutoHotkey_L/pulls) open

### Description
I deleted the word **See** in row 17 since the word **see** already exists in the prextex.