### PR TITLE
Tweak the rendering of the bibliography to an unordered list.

### DIFF
--- a/lib/asciidoctor-bibtex/processor.rb
+++ b/lib/asciidoctor-bibtex/processor.rb
@@ -138,7 +138,11 @@ module AsciidoctorBibtex
     #
     # Return an array of texts representing an asciidoc list.
     def build_bibliography_list
+
       result = []
+      result << '[.text-left]'
+      result << '[unstyled]'
+
       @citations.each_with_index do |ref, index|
         result << build_bibliography_item(ref, index)
         result << ''
@@ -170,7 +174,7 @@ module AsciidoctorBibtex
     # Build bibliography text for a given reference
     def build_bibliography_item(key, index = 0)
       index += 1
-      result = ''
+      result = '* '
 
       begin
         cptext = if @biblio[key].nil?


### PR DESCRIPTION
DISCLAIMER: this is not a serious suggestion as in a proposal to merge. I just needed to solve #76 for me quickly. I'm sure there's a much better way to solve this, but I am completely without any Ruby skills whatsoever.

Previously, the bibliography entries have been rendered as individual paragraphs. This commit tweaks the rendering to rather use an unstyled, left-aligned, unordered list.

This essentially fixes asciidoctor/asciidoctor-bibtex#76 and relates to asciidoctor/asciidoctor-pdf#1889.

