### PR TITLE
Add support for multiple bibliography files

### DIFF
--- a/test/data/test-multiple.bib
+++ b/test/data/test-multiple.bib
@@ -1,0 +1,6 @@
+@book{brown10,
+  editor = {J. Brown Jr},
+  title = {Other book title},
+  publisher = {OUP},
+  year = {2010}
+}

--- a/test/formats_test.rb
+++ b/test/formats_test.rb
@@ -12,7 +12,7 @@ include AsciidoctorBibtex
 describe AsciidoctorBibtex do
 
   def check_complete_citation style, line, result, links = false
-    p = Processor.new 'test/data/test.bib', links, style
+    p = Processor.new ['test/data/test.bib'], links, style
     p.process_citation_macros(line)
     _(p.build_citation_text(CitationMacro.extract_macros(line).first)).must_equal "[.citation]##{result}#"
   end

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -11,37 +11,46 @@ include AsciidoctorBibtex
 
 describe AsciidoctorBibtex do
   it "must return Chicago style references" do
-    p = Processor.new 'test/data/test.bib', false, 'chicago-author-date'
+    p = Processor.new ['test/data/test.bib'], false, 'chicago-author-date'
     _(p.build_bibliography_item('smith10')).must_equal "Smith, D. 2010. _Book Title_. Mahwah, NJ: Lawrence Erlbaum."
     _(p.build_bibliography_item('brown09')).must_equal "Brown, J., ed. 2009. _Book Title_. OUP."
   end
 
   it "must return numeric style (IEEE) references" do
-    p = Processor.new 'test/data/test.bib', false, 'ieee'
+    p = Processor.new ['test/data/test.bib'], false, 'ieee'
     _(p.build_bibliography_item('smith10', 0)).must_equal "[1] D. Smith, _Book title_. Mahwah, NJ: Lawrence Erlbaum, 2010."
     _(p.build_bibliography_item('brown09', 1)).must_equal "[2] J. Brown, Ed., _Book title_. OUP, 2009."
   end
 
   it "must support custom template in numeric style (IEEE) references" do
-    p = Processor.new 'test/data/test.bib', false, 'ieee', custom_citation_template: '/$id/'
+    p = Processor.new ['test/data/test.bib'], false, 'ieee', custom_citation_template: '/$id/'
     _(p.build_bibliography_item('smith10', 0)).must_equal "/1/ D. Smith, _Book title_. Mahwah, NJ: Lawrence Erlbaum, 2010."
     _(p.build_bibliography_item('brown09', 1)).must_equal "/2/ J. Brown, Ed., _Book title_. OUP, 2009."
   end
 
   it "must return harvard style (APA) references" do
-    p = Processor.new 'test/data/test.bib', false, 'apa'
+    p = Processor.new ['test/data/test.bib'], false, 'apa'
     _(p.build_bibliography_item('smith10')).must_equal "Smith, D. (2010). _Book title_. Lawrence Erlbaum."
     _(p.build_bibliography_item('brown09')).must_equal "Brown, J. (Ed.). (2009). _Book title_. OUP."
   end
 
   it "must sort citations correctly" do
     begin
-      p = Processor.new 'test/data/sort.bib', true, 'ieee'
+      p = Processor.new ['test/data/sort.bib'], true, 'ieee'
       p.process_citation_macros 'cite:[Morgan2018, Morgan2006]'
       p.finalize_macro_processing
     rescue
       fail 'Should not throw exception when sorting citations'
     end
   end
+
+  it "must handle multiple bibliographies" do
+    p = Processor.new ['test/data/test.bib', 'test/data/test-multiple.bib'], false, 'ieee'
+    _(p.build_bibliography_item('brown10', 0)).must_equal "[1] J. B. Jr, Ed., _Other book title_. OUP, 2010."
+    _(p.build_bibliography_item('smith10', 1)).must_equal "[2] D. Smith, _Book title_. Mahwah, NJ: Lawrence Erlbaum, 2010."
+    _(p.build_bibliography_item('brown09', 2)).must_equal "[3] J. Brown, Ed., _Book title_. OUP, 2009."
+
+  end
+
 end
 


### PR DESCRIPTION
Adds support for multiple bibliography files.

Introduces support for multiple bibliography files using the added `bibtex-files` attribute (plural form of the existing `bibtex-file`).

The `bibtex-files` attribute takes a comma separated list of files, and searches for entries prioritising the first file.