### PR TITLE
Add attribute support to asciidoctor-bibtex

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -139,6 +139,11 @@ Configuration is applied in the form of AsciiDoc document attributes, which must
 | Custom citation template for numeric style
 | Any string matching `/(.+?)\$id(.+)/`
 | `[$id]`
+
+| bibtex-attributes
+| Also process attributes
+| `true` or `false`
+| `false`
 |===
 
 === Commandline

--- a/lib/asciidoctor-bibtex/extensions.rb
+++ b/lib/asciidoctor-bibtex/extensions.rb
@@ -60,30 +60,6 @@ module AsciidoctorBibtex
     # only produce texts with inline macros.
     #
     class CitationProcessor < ::Asciidoctor::Extensions::Treeprocessor
-
-      def process_line_with_attributes(line, processor, pending_attributes, bibtex_attributes)
-        return if line.nil? || line.empty?
-        if bibtex_attributes == 'false'
-          processor.process_citation_macros(line)
-          return
-        end
-
-        while line.match(/(?<!\\)\{([^} ]+)\}/)
-          attribute = $1
-          line_before_attribute = $`
-          line_after_attribute = $'
-
-          processor.process_citation_macros(line_before_attribute)
-          if pending_attributes.include?(attribute)
-            processor.process_citation_macros(pending_attributes[attribute])
-          end
-
-          line = line_after_attribute
-        end
-        processor.process_citation_macros(line)
-
-      end
-      
       def process(document)
         bibtex_file = (document.attr 'bibtex-file').to_s
         bibtex_style = ((document.attr 'bibtex-style') || 'ieee').to_s
@@ -144,15 +120,15 @@ module AsciidoctorBibtex
             # ghost footnotes will be inserted (as of asciidoctor 2.0.10).
             line = block.instance_variable_get(:@text)
             unless line.nil? || line.empty?
-              process_line_with_attributes(line, processor, pending_attributes, bibtex_attributes)
+              processor.process_line_with_attributes(line, pending_attributes, bibtex_attributes)
             end
           elsif block.content_model == :simple
             block.lines.each do |line|
-              process_line_with_attributes(line, processor, pending_attributes, bibtex_attributes)
+              processor.process_line_with_attributes(line, pending_attributes, bibtex_attributes)
             end
           else
             line = block.instance_variable_get(:@title)
-            process_line_with_attributes(line, processor, pending_attributes, bibtex_attributes)
+            processor.process_line_with_attributes(line, pending_attributes, bibtex_attributes)
           end
         end
         # Make processor finalize macro processing as required.

--- a/lib/asciidoctor-bibtex/extensions.rb
+++ b/lib/asciidoctor-bibtex/extensions.rb
@@ -123,7 +123,6 @@ module AsciidoctorBibtex
                                   bibtex_order == :appearance, bibtex_format,
                                   bibtex_throw == 'true', custom_citation_template: bibtex_citation_template
 
-
         # First pass: extract all citations.
         prose_blocks.each do |block|
           if block.attributes[:attribute_entries]

--- a/lib/asciidoctor-bibtex/extensions.rb
+++ b/lib/asciidoctor-bibtex/extensions.rb
@@ -110,8 +110,10 @@ module AsciidoctorBibtex
         end
 
         pending_attributes = {}
-        document.attributes.each do |name, value|
-          pending_attributes[name] = value
+        if bibtex_attributes == 'true'
+          document.attributes.each do |name, value|
+            pending_attributes[name] = value
+          end
         end
 
         # Extract all AST nodes that can contain citations.
@@ -130,7 +132,7 @@ module AsciidoctorBibtex
 
         # First pass: extract all citations.
         prose_blocks.each do |block|
-          if block.attributes[:attribute_entries]
+          if bibtex_attributes == 'true' && block.attributes[:attribute_entries]
             block.attributes[:attribute_entries].each do |attr|
               pending_attributes[attr.name] = attr.value
             end

--- a/lib/asciidoctor-bibtex/processor.rb
+++ b/lib/asciidoctor-bibtex/processor.rb
@@ -88,6 +88,33 @@ module AsciidoctorBibtex
       end
     end
 
+    # Process a line with attributes.
+    #
+    # This function takes a line of text and processes it based on the presence of attributes.
+    def process_line_with_attributes(line, pending_attributes, bibtex_attributes)
+      if line.nil? || line.empty?
+        return
+      end
+      if bibtex_attributes == 'false'
+        process_citation_macros(line)
+        return
+      end
+
+      while line.match(/(?<!\\)\{([^} ]+)\}/)
+        attribute = $1
+        line_before_attribute = $`
+        line_after_attribute = $'
+
+        process_citation_macros(line_before_attribute)
+        if pending_attributes.include?(attribute)
+          process_citation_macros(pending_attributes[attribute])
+        end
+
+        line = line_after_attribute
+      end
+      process_citation_macros(line)
+    end
+
     # Finalize citation macro processing and build internal citation list.
     #
     # As this function being called, processor will clean up the list of

--- a/samples/all-in-one/sample.adoc
+++ b/samples/all-in-one/sample.adoc
@@ -66,7 +66,6 @@ Shall also work in a document asciidoc attribute: {block-attribute}
 
 Shall also work in a block asciidoc attribute: {document-attribute}
 
-
 [sect2] 
 == Bibliography
 

--- a/samples/all-in-one/sample.adoc
+++ b/samples/all-in-one/sample.adoc
@@ -2,6 +2,7 @@
 :bibtex-file: references.bib
 :bibtex-order: alphabetical
 :bibtex-style: ieee
+:document-attribute: This text is included from a document attribute. See cite:[Lane12a].
 
 
 == Samples
@@ -58,6 +59,12 @@ Shall also work in block title:
 | Illustrated in cite:[Lane12a].
 |===
 include::sample-include.adoc[]
+
+:block-attribute: This text is included from a block attribute. See cite:[Lane12a].
+
+Shall also work in a document asciidoc attribute: {block-attribute}
+
+Shall also work in a block asciidoc attribute: {document-attribute}
 
 
 [sect2] 

--- a/samples/all-in-one/sample.adoc
+++ b/samples/all-in-one/sample.adoc
@@ -2,6 +2,7 @@
 :bibtex-file: references.bib
 :bibtex-order: alphabetical
 :bibtex-style: ieee
+:bibtex-attributes: true
 :document-attribute: This text is included from a document attribute. See cite:[Lane12a].
 
 

--- a/samples/citations_in_attributes/references.bib
+++ b/samples/citations_in_attributes/references.bib
@@ -1,0 +1,31 @@
+@book{Lane12a,
+	author = {P. Lane},
+	title =	 {Book title},
+	publisher = {Publisher},
+	year =	 {2000}
+}
+
+@book{Lane12b,
+	author = {K. Mane and D. Smith},
+	title =	 {Book title},
+	publisher = {Publisher},
+	year =	 {2000}
+}
+
+@book{Anderson98,
+	editor = {J. R. Anderson and C. Lebiere},
+	title = {The Atomic Components of Thought},
+	publisher = {Lawrence Erlbaum},
+        address = {Mahwah, NJ},
+	year = {1998}
+}
+
+@article{Anderson04,
+	author = {J. R. Anderson and D. Bothell and M. D. Byrne and S. Douglass and C. Lebiere and Y. L. Qin},
+	title = {An integrated theory of the mind},
+	journal = {Psychological Review},
+	volume = {111},
+	number = {4},
+	pages = {1036--1060},
+	year = {2004}
+}

--- a/samples/citations_in_attributes/sample.adoc
+++ b/samples/citations_in_attributes/sample.adoc
@@ -1,6 +1,7 @@
 = Sample of using asciidoctor-bibtex
 :bibtex-file: references.bib
 :bibtex-style: ieee
+:bibtex-attributes: true
 :document-attribute: This text is included from a document attribute. Must be 3 cite:[Anderson98].
 
 :block-attribute: This text is included from a block attribute. Must be 2 cite:[Lane12b].

--- a/samples/citations_in_attributes/sample.adoc
+++ b/samples/citations_in_attributes/sample.adoc
@@ -1,0 +1,15 @@
+= Sample of using asciidoctor-bibtex
+:bibtex-file: references.bib
+:bibtex-style: ieee
+:document-attribute: This text is included from a document attribute. Must be 3 cite:[Anderson98].
+
+:block-attribute: This text is included from a block attribute. Must be 2 cite:[Lane12b].
+
+Order of the citations must be correct, must be 1: cite:[Lane12a], {block-attribute}
+
+Shall also work in a block asciidoc attribute: {document-attribute} Must be 4 cite:[Anderson04].
+
+[sect2]
+== Bibliography
+
+bibliography::references.bib[ieee]


### PR DESCRIPTION
Makes replacements in citations in attributes. Supports both document and block attributes. The order of the appearance of the bibliography should be correct.

Also edited the tests. Previous tests are left as is and additionally added attribute tests which all pass.